### PR TITLE
Use UTF-8 encoded strings for websocket messages

### DIFF
--- a/RconTool/ServerConnection.cs
+++ b/RconTool/ServerConnection.cs
@@ -57,11 +57,11 @@ namespace EldoritoRcon
             if (ServerOpen != null)
                 ServerOpen(this);
 
-            ws.Send(Encoding.ASCII.GetBytes(Password));
+            ws.Send(Encoding.UTF8.GetBytes(Password));
             if (connection.serverinfo.sendOnConnect != null)
             foreach (string sc in connection.serverinfo.sendOnConnect)
             {
-                ws.Send(Encoding.ASCII.GetBytes(sc));
+                ws.Send(Encoding.UTF8.GetBytes(sc));
             }
         }
 
@@ -81,7 +81,7 @@ namespace EldoritoRcon
 
             try
             {
-                ws.Send(Encoding.ASCII.GetBytes(cmd));
+                ws.Send(Encoding.UTF8.GetBytes(cmd));
             } catch (Exception)
             {
             }


### PR DESCRIPTION
It is supported by the rcon protocol. This solves the following
issues:

	- Non-ASCII commands and chat messages/emoji sent through the tool being
	shown as ??? in the client and in the tool's textboxes;

	- Not being able to connect to servers with Rcon passwords set using non-ASCII characters. (automatically generated or not)